### PR TITLE
Fix empty susp body weird parser error thingy

### DIFF
--- a/src/ml_compiler.c
+++ b/src/ml_compiler.c
@@ -5486,6 +5486,9 @@ with_name:
 		ml_next(Parser);
 		ML_EXPR(SuspendExpr, parent, suspend);
 		SuspendExpr->Child = ml_parse_expression(Parser, EXPR_DEFAULT);
+		if (!SuspendExpr->Child) {
+			ml_parse_warn(Parser, "ParserError", "Empty susp expression");
+		}
 		if (ml_parse(Parser, MLT_COMMA)) {
 			SuspendExpr->Child->Next = ml_accept_expression(Parser, EXPR_DEFAULT);
 		}


### PR DESCRIPTION
`do susp,1` crashes minilang. This fix actually also resolved #164 before it happens, but more robustness is always nice.